### PR TITLE
fix: updated balance statement url in go example

### DIFF
--- a/sca-personal-tokens/get-statements-sca.go
+++ b/sca-personal-tokens/get-statements-sca.go
@@ -148,7 +148,7 @@ func loadPrivateKey(filePath string) (*rsa.PrivateKey, error) {
 }
 
 func doRequest(oneTimeToken, signature string, params url.Values) (*http.Response, error) {
-	u := fmt.Sprintf("%s/v3/profiles/%s/borderless-accounts/%s/statement.json",
+	u := fmt.Sprintf("%s/v1/profiles/%s/balance-statements/%s/statement.json",
 		baseURL, profileID, accountID)
 
 	url, err := url.Parse(u)


### PR DESCRIPTION
## Context

Hi,
Was running through the get statements go example here when I noticed it wasn't working.
According to the docs the pattern in the example here is deprecated in favor of https://api-docs.wise.com/partners#multi-currency-account-get-statement

Was able to run the example again by making the change to the new URL.
<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
